### PR TITLE
feat: allow toggling 'always on top'

### DIFF
--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -1,0 +1,29 @@
+'use babel';
+
+import React, { useState } from 'react';
+
+import { AlwaysOnTopIcon } from './always-on-top-icon';
+
+export const AlwaysOnTopButton = () => {
+  const [alwaysOnTop, setAlwaysOnTop] = useState(() =>
+    inkdrop.window.isAlwaysOnTop()
+  );
+
+  return (
+    <button
+      onClick={() => {
+        inkdrop.commands.dispatch(document.body, 'always-on-top:toggle');
+        setAlwaysOnTop(inkdrop.window.isAlwaysOnTop());
+      }}
+      title="Toggle Always On Top"
+      className="always-on-top-button mde-toolbar-item"
+    >
+      <AlwaysOnTopIcon
+        title="Toggle Always On Top"
+        titleId="always-on-top-icon"
+        className="svg-icon streamline always-on-top"
+        fill={alwaysOnTop ? 'green' : '#fff'}
+      />
+    </button>
+  );
+};

--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -1,6 +1,6 @@
 'use babel';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { AlwaysOnTopIcon } from './always-on-top-icon';
 
@@ -9,11 +9,17 @@ export const AlwaysOnTopButton = () => {
     inkdrop.window.isAlwaysOnTop()
   );
 
+  // listens to the always on top command and updates local state
+  useEffect(() => {
+    return inkdrop.commands.add(document.body, 'always-on-top:toggle', () => {
+      setAlwaysOnTop(inkdrop.window.isAlwaysOnTop());
+    }).dispose;
+  }, []);
+
   return (
     <button
       onClick={() => {
         inkdrop.commands.dispatch(document.body, 'always-on-top:toggle');
-        setAlwaysOnTop(inkdrop.window.isAlwaysOnTop());
       }}
       title="Toggle Always On Top"
       className="always-on-top-button mde-toolbar-item"

--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -23,17 +23,12 @@ export const AlwaysOnTopButton = () => {
           inkdrop.commands.dispatch(document.body, 'always-on-top:toggle');
         }}
         title="Toggle Always On Top"
-        className="always-on-top-button"
+        className={`always-on-top-button ${alwaysOnTop ? 'active' : ''}`}
       >
         <AlwaysOnTopIcon
           title="Toggle Always On Top"
           titleId="always-on-top-icon"
           className="svg-icon streamline always-on-top"
-          style={{
-            fill: alwaysOnTop
-              ? 'var(--primary-color)'
-              : 'var(--light-text-color)',
-          }}
         />
       </button>
     </div>

--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -17,23 +17,25 @@ export const AlwaysOnTopButton = () => {
   }, []);
 
   return (
-    <button
-      onClick={() => {
-        inkdrop.commands.dispatch(document.body, 'always-on-top:toggle');
-      }}
-      title="Toggle Always On Top"
-      className="always-on-top-button mde-toolbar-item"
-    >
-      <AlwaysOnTopIcon
-        title="Toggle Always On Top"
-        titleId="always-on-top-icon"
-        className="svg-icon streamline always-on-top"
-        style={{
-          fill: alwaysOnTop
-            ? 'var(--primary-color)'
-            : 'var(--light-text-color)',
+    <div className="editor-header-always-on-top">
+      <button
+        onClick={() => {
+          inkdrop.commands.dispatch(document.body, 'always-on-top:toggle');
         }}
-      />
-    </button>
+        title="Toggle Always On Top"
+        className="always-on-top-button"
+      >
+        <AlwaysOnTopIcon
+          title="Toggle Always On Top"
+          titleId="always-on-top-icon"
+          className="svg-icon streamline always-on-top"
+          style={{
+            fill: alwaysOnTop
+              ? 'var(--primary-color)'
+              : 'var(--light-text-color)',
+          }}
+        />
+      </button>
+    </div>
   );
 };

--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -30,7 +30,7 @@ export const AlwaysOnTopButton = () => {
         className="svg-icon streamline always-on-top"
         style={{
           fill: alwaysOnTop
-            ? 'var(--positive-color)'
+            ? 'var(--primary-color)'
             : 'var(--light-text-color)',
         }}
       />

--- a/lib/always-on-top-button.js
+++ b/lib/always-on-top-button.js
@@ -28,7 +28,11 @@ export const AlwaysOnTopButton = () => {
         title="Toggle Always On Top"
         titleId="always-on-top-icon"
         className="svg-icon streamline always-on-top"
-        fill={alwaysOnTop ? 'green' : '#fff'}
+        style={{
+          fill: alwaysOnTop
+            ? 'var(--positive-color)'
+            : 'var(--light-text-color)',
+        }}
       />
     </button>
   );

--- a/lib/always-on-top-icon.js
+++ b/lib/always-on-top-icon.js
@@ -5,14 +5,15 @@ import React, { memo } from 'react';
 const SvgComponent = ({ title, titleId, ...props }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 384 512"
+    viewBox="0 0 24 24"
     height="1em"
     width="1em"
     aria-labelledby={titleId}
-    {...props}
   >
     {title ? <title id={titleId}>{title}</title> : null}
-    <path d="M54.63 246.6 192 109.3l137.4 137.4c6.2 6.2 14.4 9.3 22.6 9.3s16.38-3.125 22.62-9.375c12.5-12.5 12.5-32.75 0-45.25l-160-160c-12.5-12.5-32.75-12.5-45.25 0l-160 160c-12.5 12.5-12.5 32.75 0 45.25s32.76 12.475 45.26-.025zm159.97-13.2c-12.5-12.5-32.75-12.5-45.25 0l-160 160c-12.5 12.5-12.5 32.75 0 45.25s32.75 12.5 45.25 0L192 301.3l137.4 137.4c6.2 6.2 14.4 9.3 22.6 9.3s16.38-3.125 22.62-9.375c12.5-12.5 12.5-32.75 0-45.25L214.6 233.4z" />
+    <line x1="12" y1="5.248" x2="12" y2="23.248" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"></line>
+    <polyline points="8.25 8.998 12 5.248 15.75 8.998" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"></polyline>
+    <line x1="0.75" y1="0.748" x2="23.25" y2="0.748" fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round"></line>
   </svg>
 );
 

--- a/lib/always-on-top-icon.js
+++ b/lib/always-on-top-icon.js
@@ -1,0 +1,19 @@
+'use babel';
+
+import React, { memo } from 'react';
+
+const SvgComponent = ({ title, titleId, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 384 512"
+    height="1em"
+    width="1em"
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path d="M54.63 246.6 192 109.3l137.4 137.4c6.2 6.2 14.4 9.3 22.6 9.3s16.38-3.125 22.62-9.375c12.5-12.5 12.5-32.75 0-45.25l-160-160c-12.5-12.5-32.75-12.5-45.25 0l-160 160c-12.5 12.5-12.5 32.75 0 45.25s32.76 12.475 45.26-.025zm159.97-13.2c-12.5-12.5-32.75-12.5-45.25 0l-160 160c-12.5 12.5-12.5 32.75 0 45.25s32.75 12.5 45.25 0L192 301.3l137.4 137.4c6.2 6.2 14.4 9.3 22.6 9.3s16.38-3.125 22.62-9.375c12.5-12.5 12.5-32.75 0-45.25L214.6 233.4z" />
+  </svg>
+);
+
+export const AlwaysOnTopIcon = memo(SvgComponent);

--- a/lib/always-on-top.js
+++ b/lib/always-on-top.js
@@ -18,8 +18,8 @@ class AlwaysOnTopPlugin {
 
     inkdrop.components.registerClass(AlwaysOnTopButton);
     inkdrop.layouts.insertComponentToLayoutBefore(
-      'editor-floating-actions',
-      'toolbar-item-preview',
+      'editor-header',
+      'EditorHeaderMore',
       'AlwaysOnTopButton'
     );
   }
@@ -27,7 +27,7 @@ class AlwaysOnTopPlugin {
   deactivate() {
     inkdrop.window.setAlwaysOnTop(false);
     inkdrop.layouts.removeComponentFromLayout(
-      'editor-floating-actions',
+      'editor-header',
       'AlwaysOnTopButton'
     );
     inkdrop.components.deleteClass(AlwaysOnTopButton);

--- a/lib/always-on-top.js
+++ b/lib/always-on-top.js
@@ -1,8 +1,38 @@
-module.exports = {
+'use babel';
+
+import { CompositeDisposable } from 'event-kit';
+
+import { AlwaysOnTopButton } from './always-on-top-button';
+
+class AlwaysOnTopPlugin {
+  constructor() {
+    this.disposables = new CompositeDisposable();
+  }
+
   activate() {
-    inkdrop.window.setAlwaysOnTop(true)
-  },
+    const toggleCommand = inkdrop.commands.add(document.body, {
+      'always-on-top:toggle': () =>
+        inkdrop.window.setAlwaysOnTop(!inkdrop.window.isAlwaysOnTop()),
+    });
+    this.disposables.add(toggleCommand);
+
+    inkdrop.components.registerClass(AlwaysOnTopButton);
+    inkdrop.layouts.insertComponentToLayoutBefore(
+      'editor-floating-actions',
+      'toolbar-item-preview',
+      'AlwaysOnTopButton'
+    );
+  }
+
   deactivate() {
-    inkdrop.window.setAlwaysOnTop(false)
+    inkdrop.window.setAlwaysOnTop(false);
+    inkdrop.layouts.removeComponentFromLayout(
+      'editor-floating-actions',
+      'AlwaysOnTopButton'
+    );
+    inkdrop.components.deleteClass(AlwaysOnTopButton);
+    this.disposables.dispose();
   }
 }
+
+module.exports = new AlwaysOnTopPlugin();

--- a/menus/toggle-button.json
+++ b/menus/toggle-button.json
@@ -1,0 +1,26 @@
+{
+  "context-menu": {
+    ".CodeMirror": [
+      {
+        "label": "Toggle Always On Top",
+        "command": "always-on-top:toggle"
+      }
+    ]
+  },
+  "menu": [
+    {
+      "label": "Plugins",
+      "submenu": [
+        {
+          "label": "always-on-top",
+          "submenu": [
+            {
+              "label": "Toggle Always On Top",
+              "command": "always-on-top:toggle"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/styles/always-on-top.less
+++ b/styles/always-on-top.less
@@ -1,4 +1,36 @@
+.editor-header-always-on-top {
+  flex: 0;
+  padding-top: 10px;
+  opacity: 0.5;
+  transition: 0.4s ease-in-out;
+  font-size: 16px;
+  margin-right: 0.3rem;
+}
+
 .always-on-top-button {
-  min-width: 1rem;
-  min-height: 1rem;
+  display: inline-block;
+  background: transparent;
+  text-align: center;
+  text-decoration: none !important;
+  color: var(--light-text-color);
+  width: 32px;
+  height: 32px;
+  padding-top: 6px;
+  margin: 0;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  cursor: pointer;
+  outline: none;
+
+  path,
+  circle {
+    stroke: var(--light-text-color);
+  }
+
+  &.active,
+  &:hover {
+    background: var(--white-active);
+    color: var(--light-text-color);
+    border-color: var(--light-text-color);
+  }
 }

--- a/styles/always-on-top.less
+++ b/styles/always-on-top.less
@@ -22,15 +22,25 @@
   cursor: pointer;
   outline: none;
 
-  path,
-  circle {
-    stroke: var(--light-text-color);
+  svg:not(:root) {
+    overflow: visible;
+    stroke-width: 1.5px;
   }
 
-  &.active,
   &:hover {
     background: var(--white-active);
     color: var(--light-text-color);
     border-color: var(--light-text-color);
   }
+
+  &.active {
+    color: var(--primary-color) !important;
+    svg:not(:root) {
+      stroke-width: 3px;
+    }
+  }
+}
+
+.editor-header-layout:hover .editor-header-always-on-top {
+  opacity: 1;
 }

--- a/styles/always-on-top.less
+++ b/styles/always-on-top.less
@@ -1,0 +1,4 @@
+.always-on-top-button {
+  min-width: 1rem;
+  min-height: 1rem;
+}


### PR DESCRIPTION
# Motivation
Toggling Always on Top by enabling / disabling the plugin was not the greatest user experience... sometimes a note needs to be on top quickly and opening preferences, clicking plugins, searching for the plugin and toggling it was inconvenient.

# Changes
This change adds both a button to the editor floating actions and a menu
item allowing the user to toggle the always on top functionality.

# Demo
https://user-images.githubusercontent.com/551858/184578719-c424f0b4-597d-438d-87f7-60a4a0143b00.mp4

<img width="411" alt="image" src="https://user-images.githubusercontent.com/551858/184579078-7a56f4c1-41e3-4708-bfe0-3452eac2c134.png">

# Toggling Always On Top From The Menu

https://user-images.githubusercontent.com/551858/184783455-c951e62f-a96c-4064-8717-11e1550d6ab7.mp4

# Light Theme Compatible
(using CSS variables)

![CleanShot 2022-08-15 at 21 35 17@2x](https://user-images.githubusercontent.com/551858/184786397-d68dcf7a-2848-466c-82f8-fb8b076d59e0.png)

<img width="853" alt="image" src="https://user-images.githubusercontent.com/551858/184786430-7fe67262-f67e-4049-97c9-97ca968b00ae.png">



